### PR TITLE
fix(BaseGrid): improve entity retrieval and error handling

### DIFF
--- a/src/Component/BaseGrid.php
+++ b/src/Component/BaseGrid.php
@@ -174,7 +174,10 @@ abstract class BaseGrid extends Control
 			try {
 				$this->getPresenter()->{$methodName}($id);
 			} catch (InvalidLinkException|TypeError) {
-				$row = $this->createQueryObject()->byId($id)->getQuery()->getSingleResult();
+				$row = $this->createQueryObject()->byId($id)->getQuery()->getOneOrNullResult();
+				if ($row === null) {
+					$this->getPresenter()->error();
+				}
 				if (is_array($row)) {
 					$entity = $row[0];
 				} else {
@@ -188,7 +191,11 @@ abstract class BaseGrid extends Control
 			try {
 				$this->getPresenter()->redirect($this->allowEdit()->redirect, $id);
 			} catch (InvalidLinkException) {
-				$this->getPresenter()->redirect($this->allowEdit()->redirect, $this->createQueryObject()->byId($id)->fetchOne());
+				$entity = $this->createQueryObject()->byId($id)->fetchOneOrNull();
+				if ($entity === null) {
+					$this->getPresenter()->error();
+				}
+				$this->getPresenter()->redirect($this->allowEdit()->redirect, $entity);
 			}
 		}
 	}
@@ -238,12 +245,11 @@ abstract class BaseGrid extends Control
 			$this->getPresenter()->error();
 		}
 
-		$row = $this->createQueryObject()->byId($id)->getQuery()->getSingleResult();
-		if (is_array($row)) {
-			$entity = $row[0];
-		} else {
-			$entity = $row;
+		$row = $this->createQueryObject()->byId($id)->getQuery()->getOneOrNullResult();
+		if ($row === null) {
+			$this->getPresenter()->error();
 		}
+		$entity = is_array($row) ? $row[0] : $row;
 
 		if ($this->allowDelete()->onDelete && !($this->allowDelete()->onDelete)($entity)) {
 			return;

--- a/src/Component/BaseGrid.php
+++ b/src/Component/BaseGrid.php
@@ -174,7 +174,9 @@ abstract class BaseGrid extends Control
 			try {
 				$this->getPresenter()->{$methodName}($id);
 			} catch (InvalidLinkException|TypeError) {
-				$row = $this->createQueryObject()->byId($id)->getQuery()->getSingleResult();
+				$queryObject = $this->createQueryObject();
+				$this->initQueryObject($queryObject);
+				$row = $queryObject->byId($id)->getQuery()->getSingleResult();
 				if (is_array($row)) {
 					$entity = $row[0];
 				} else {
@@ -188,7 +190,9 @@ abstract class BaseGrid extends Control
 			try {
 				$this->getPresenter()->redirect($this->allowEdit()->redirect, $id);
 			} catch (InvalidLinkException) {
-				$this->getPresenter()->redirect($this->allowEdit()->redirect, $this->createQueryObject()->byId($id)->fetchOne());
+				$queryObject = $this->createQueryObject();
+				$this->initQueryObject($queryObject);
+				$this->getPresenter()->redirect($this->allowEdit()->redirect, $queryObject->byId($id)->fetchOne());
 			}
 		}
 	}
@@ -238,7 +242,9 @@ abstract class BaseGrid extends Control
 			$this->getPresenter()->error();
 		}
 
-		$row = $this->createQueryObject()->byId($id)->getQuery()->getSingleResult();
+		$queryObject = $this->createQueryObject();
+		$this->initQueryObject($queryObject);
+		$row = $queryObject->byId($id)->getQuery()->getSingleResult();
 		if (is_array($row)) {
 			$entity = $row[0];
 		} else {

--- a/src/Component/BaseGrid.php
+++ b/src/Component/BaseGrid.php
@@ -174,10 +174,7 @@ abstract class BaseGrid extends Control
 			try {
 				$this->getPresenter()->{$methodName}($id);
 			} catch (InvalidLinkException|TypeError) {
-				$row = $this->createQueryObject()->byId($id)->getQuery()->getOneOrNullResult();
-				if ($row === null) {
-					$this->getPresenter()->error();
-				}
+				$row = $this->createQueryObject()->byId($id)->getQuery()->getSingleResult();
 				if (is_array($row)) {
 					$entity = $row[0];
 				} else {
@@ -191,11 +188,7 @@ abstract class BaseGrid extends Control
 			try {
 				$this->getPresenter()->redirect($this->allowEdit()->redirect, $id);
 			} catch (InvalidLinkException) {
-				$entity = $this->createQueryObject()->byId($id)->fetchOneOrNull();
-				if ($entity === null) {
-					$this->getPresenter()->error();
-				}
-				$this->getPresenter()->redirect($this->allowEdit()->redirect, $entity);
+				$this->getPresenter()->redirect($this->allowEdit()->redirect, $this->createQueryObject()->byId($id)->fetchOne());
 			}
 		}
 	}
@@ -245,11 +238,12 @@ abstract class BaseGrid extends Control
 			$this->getPresenter()->error();
 		}
 
-		$row = $this->createQueryObject()->byId($id)->getQuery()->getOneOrNullResult();
-		if ($row === null) {
-			$this->getPresenter()->error();
+		$row = $this->createQueryObject()->byId($id)->getQuery()->getSingleResult();
+		if (is_array($row)) {
+			$entity = $row[0];
+		} else {
+			$entity = $row;
 		}
-		$entity = is_array($row) ? $row[0] : $row;
 
 		if ($this->allowDelete()->onDelete && !($this->allowDelete()->onDelete)($entity)) {
 			return;


### PR DESCRIPTION
- Replace getSingleResult() with getOneOrNullResult() to handle missing entities
- Add null check to trigger presenter error when entity not found
- Maintain backward compatibility with array and object result handling